### PR TITLE
가독성 개선을 위한 다이어그램 레이아웃 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,13 @@ Rel(bc3, bc4, "Sends messages to", "sync")
 Rel(bc1, mh, "Publishes messages to")
 Rel(bc3, mh, "Subscribes")
 
-UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="3")
+UpdateRelStyle(bc1, bc2, $offsetY="-10", $offsetX="5")
+UpdateRelStyle(bc3, bc2, $offsetX="-100")
+UpdateRelStyle(bc1, mh, $offsetY="-15", $offsetX="-60")
+UpdateRelStyle(bc3, mh, $offsetY="-90", $offsetX="20")
+UpdateRelStyle(bc3, bc4, $offsetY="-10", $offsetX="5")
+
+UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="3")
 
 UpdateElementStyle(fs1, $bgColor="lightgrey", $borderColor="grey")
 ```
@@ -220,7 +226,10 @@ Enterprise_Boundary(wb, "System") {
 Rel(bc2, fs1, "Makes API calls to", "HTTP")
 Rel(bc3, fs1, "Makes API calls to", "HTTP")
 
-UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="3")
+UpdateRelStyle(bc2, fs1, $offsetY="-30", $offsetX="-45")
+UpdateRelStyle(bc3, fs1, $offsetY="-35", $offsetX="-80")
+
+UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="3")
 
 UpdateElementStyle(bc1, $bgColor="lightgrey", $borderColor="grey")
 UpdateElementStyle(bc4, $bgColor="lightgrey", $borderColor="grey")
@@ -255,7 +264,11 @@ Rel(bc3, ls3, "Depends on", "HTTP")
 Rel(bc4, ls1, "Depends on", "HTTP")
 Rel(bc4, ls2, "Depends on", "HTTP")
 
-UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="3")
+UpdateRelStyle(bc3, ls3, $offsetY="10", $offsetX="-30")
+UpdateRelStyle(bc4, ls1, $offsetY="-100", $offsetX="-40")
+UpdateRelStyle(bc4, ls2, $offsetY="-80", $offsetX="-40")
+
+UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="3")
 
 UpdateElementStyle(bc1, $bgColor="lightgrey", $borderColor="grey")
 UpdateElementStyle(bc2, $bgColor="lightgrey", $borderColor="grey")


### PR DESCRIPTION
문서를 읽던 중 **Bounded Context 간 의존성** 다이어그램 안의 관계 부분이 가독성이 떨어져 변경했습니다.
**플랫폼 서비스**와 **레거시 시스템 사용**의 다이어그램도 일관된 느낌을 주기 위해 함께 변경했습니다.
검토 부탁드립니다.

변경 내용을 rich diff 로 볼 때 **Bounded Context 간 의존성** 다이어그램이 두 개로 보이는 문제가 있어서 [미리보기](https://github.com/jinhoyim/ArchitecturalRunwayGuidelines/tree/diagram-layout?tab=readme-ov-file#bounded-context-%EA%B0%84-%EC%9D%98%EC%A1%B4%EC%84%B1) 링크를 첨부합니다.